### PR TITLE
Allow overwriting paths to external dependencies and default to "py -2"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /lib
 /test/bin
 
+# local overides
+/vsbuild/external_dependencies_local.props
+
 # build intermediates:
 /vsbuild/Release
 /vsbuild/Debug

--- a/vsbuild/external_dependencies.props
+++ b/vsbuild/external_dependencies.props
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="PropertySheets" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="external_dependencies_local.props" Condition="Exists('external_dependencies_local.props')"/>
+  </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <BOOST_PATH>..\..\boost_1_66_0</BOOST_PATH>
-    <GTEST_PATH>..\..\googletest.git</GTEST_PATH>
+    <BOOST_PATH Condition="'$(BOOST_PATH)'==''">..\..\boost_1_66_0</BOOST_PATH>
+    <GTEST_PATH Condition="'$(GTEST_PATH)'==''">..\..\googletest.git</GTEST_PATH>
+    <PYTHON2_CMD Condition="'$(PYTHON2_CMD)'==''">py -2</PYTHON2_CMD>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />
@@ -13,6 +16,9 @@
     </BuildMacro>
     <BuildMacro Include="GTEST_PATH">
       <Value>$(GTEST_PATH)</Value>
+    </BuildMacro>
+    <BuildMacro Include="PYTHON2_CMD">
+      <Value>$(PYTHON2_CMD)</Value>
     </BuildMacro>
   </ItemGroup>
 </Project>

--- a/vsbuild/external_dependencies.props
+++ b/vsbuild/external_dependencies.props
@@ -5,7 +5,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <BOOST_PATH Condition="'$(BOOST_PATH)'==''">..\..\boost_1_66_0</BOOST_PATH>
-    <GTEST_PATH Condition="'$(GTEST_PATH)'==''">..\..\googletest.git</GTEST_PATH>
+    <GTEST_PATH Condition="'$(GTEST_PATH)'==''">..\..\googletest</GTEST_PATH>
     <PYTHON2_CMD Condition="'$(PYTHON2_CMD)'==''">py -2</PYTHON2_CMD>
   </PropertyGroup>
   <PropertyGroup />

--- a/vsbuild/external_dependencies.props
+++ b/vsbuild/external_dependencies.props
@@ -6,7 +6,6 @@
   <PropertyGroup Label="UserMacros">
     <BOOST_PATH Condition="'$(BOOST_PATH)'==''">..\..\boost_1_66_0</BOOST_PATH>
     <GTEST_PATH Condition="'$(GTEST_PATH)'==''">..\..\googletest</GTEST_PATH>
-    <PYTHON2_CMD Condition="'$(PYTHON2_CMD)'==''">py -2</PYTHON2_CMD>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />
@@ -16,9 +15,6 @@
     </BuildMacro>
     <BuildMacro Include="GTEST_PATH">
       <Value>$(GTEST_PATH)</Value>
-    </BuildMacro>
-    <BuildMacro Include="PYTHON2_CMD">
-      <Value>$(PYTHON2_CMD)</Value>
     </BuildMacro>
   </ItemGroup>
 </Project>

--- a/vsbuild/udis86.vcxproj
+++ b/vsbuild/udis86.vcxproj
@@ -58,18 +58,22 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="external_dependencies.props" />
     <Import Project="common.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="external_dependencies.props" />
     <Import Project="common.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="external_dependencies.props" />
     <Import Project="common.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="external_dependencies.props" />
     <Import Project="common.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -91,7 +95,7 @@
       <AdditionalIncludeDirectories>C:\Games\MO2\build\usvfs_clean\udis86\libudis86;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <CustomBuildStep>
-      <Command>python  ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
+      <Command>$(PYTHON2_CMD) ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building udis86 optable</Message>
@@ -109,7 +113,7 @@
       <AdditionalIncludeDirectories>C:\Games\MO2\build\usvfs_clean\udis86\libudis86;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <CustomBuildStep>
-      <Command>python  ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
+      <Command>$(PYTHON2_CMD) ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building udis86 optable</Message>
@@ -133,7 +137,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <CustomBuildStep>
-      <Command>python  ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
+      <Command>$(PYTHON2_CMD) ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building udis86 optable</Message>
@@ -157,7 +161,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <CustomBuildStep>
-      <Command>python  ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
+      <Command>$(PYTHON2_CMD) ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building udis86 optable</Message>

--- a/vsbuild/udis86.vcxproj
+++ b/vsbuild/udis86.vcxproj
@@ -161,7 +161,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <CustomBuildStep>
-      <Command>$(PYTHON2_CMD) ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
+      <Command>py -2 ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86 || python ..\udis86\scripts\ud_itab.py ..\udis86\docs\x86\optable.xml ..\udis86\libudis86</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Building udis86 optable</Message>


### PR DESCRIPTION
external dependencies can now be overwritten either with environment variables or by creating
a vsbuild/external_dependencies_local.props file.
additionally, we use "py -2" by default to support cases where both python 2 and python 3 are
installed and python 3 is the default (without the need to overwrite the PYTHON2_CMD).