### PR TITLE
Wrye Bash (and other) fixes

### DIFF
--- a/src/shared/wildcard.cpp
+++ b/src/shared/wildcard.cpp
@@ -182,10 +182,13 @@ LPCSTR usvfs::shared::wildcard::PartialMatch(LPCSTR pszString, LPCSTR pszMatch)
       // in cmd.exe there seems to be no difference between <something>* and <something>*.*
       std::string temp(pszMatch, pszMatch + len - 2);
       LPCSTR pos = InnerMatch(pszString, temp.c_str());
-      if (*pos == '\0') {
-        return pszMatch + strlen(pszMatch);
-      } else {
-        return pszMatch + (pos - temp.c_str());
+      if (pos != nullptr) {
+        if (*pos == '\0') {
+          return pszMatch + strlen(pszMatch);
+        }
+        else {
+          return pszMatch + (pos - temp.c_str());
+        }
       }
     }
     return InnerMatch(pszString, pszMatch);

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -2012,6 +2012,9 @@ HANDLE WINAPI usvfs::hook_FindFirstFileExW(LPCWSTR lpFileName, FINDEX_INFO_LEVEL
     return res;
   }
 
+  WCHAR appDataLocal[MAX_PATH];
+  ::SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataLocal);
+  fs::path appDataLocalTemp = fs::path(appDataLocal) / "Temp";
   WCHAR *tempPath = new WCHAR[MAX_PATH];
   ::GetTempPathW(MAX_PATH, tempPath);
   std::wstring tempPathStr(tempPath);
@@ -2023,7 +2026,8 @@ HANDLE WINAPI usvfs::hook_FindFirstFileExW(LPCWSTR lpFileName, FINDEX_INFO_LEVEL
 
   bool usedRewrite = false;
 
-  if (std::wstring(lpFileName).find(tempPathStr) != std::wstring::npos) {
+  if (std::wstring(lpFileName).find(appDataLocalTemp.wstring()) != std::wstring::npos ||
+      std::wstring(lpFileName).find(tempPathStr) != std::wstring::npos) {
     PRE_REALCALL
     //Force the mutEXHook to match NtQueryDirectoryFile so it calls the non hooked NtQueryDirectoryFile.
     FunctionGroupLock lock(MutExHookGroup::FIND_FILES);

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -862,7 +862,7 @@ namespace usvfs {
 
       // Notice since we are calling our patched GetFileAttributesW here this will also check virtualized paths
       DWORD virtAttr = GetFileAttributesW(lpFileName);
-      m_directlyAvailable = virtAttr == INVALID_FILE_ATTRIBUTES && GetLastError() == ERROR_FILE_NOT_FOUND;
+      m_directlyAvailable = virtAttr == INVALID_FILE_ATTRIBUTES && (GetLastError() == ERROR_FILE_NOT_FOUND || GetLastError() == ERROR_PATH_NOT_FOUND);
       bool isFile = virtAttr != INVALID_FILE_ATTRIBUTES && (virtAttr & FILE_ATTRIBUTE_DIRECTORY) == 0;
       m_isDir = virtAttr != INVALID_FILE_ATTRIBUTES && (virtAttr & FILE_ATTRIBUTE_DIRECTORY);
 

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -1375,6 +1375,9 @@ BOOL WINAPI usvfs::hook_MoveFileW(LPCWSTR lpExistingFileName,
     else
       res = ::MoveFileW(readReroute.fileName(), writeReroute.fileName());
     POST_REALCALL
+
+    if (res) SetLastError(ERROR_SUCCESS);
+
     writeReroute.updateResult(callContext, res);
 
     if (res) {
@@ -1488,6 +1491,9 @@ BOOL WINAPI usvfs::hook_MoveFileExW(LPCWSTR lpExistingFileName,
     } else
       res = ::MoveFileExW(readReroute.fileName(), writeReroute.fileName(), newFlags);
     POST_REALCALL
+
+    if (res) SetLastError(ERROR_SUCCESS);
+
     writeReroute.updateResult(callContext, res);
 
     if (res) {
@@ -1600,6 +1606,9 @@ BOOL WINAPI usvfs::hook_MoveFileWithProgressW(LPCWSTR lpExistingFileName, LPCWST
 	} else
 		res = ::MoveFileWithProgressW(readReroute.fileName(), writeReroute.fileName(), lpProgressRoutine, lpData, newFlags);
   POST_REALCALL
+
+  if (res) SetLastError(ERROR_SUCCESS);
+
   writeReroute.updateResult(callContext, res);
 
   if (res) {

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -1364,7 +1364,13 @@ BOOL WINAPI usvfs::hook_MoveFileW(LPCWSTR lpExistingFileName,
       readReroute.removeMapping(READ_CONTEXT(), isDirectory);
 
       if (writeReroute.newReroute()) {
-        writeReroute.insertMapping(WRITE_CONTEXT(), isDirectory);
+        if (isDirectory) {
+          unsigned int flags = LINKFLAG_RECURSIVE;
+          if (writeReroute.newReroute()) flags |= LINKFLAG_CREATETARGET;
+          VirtualLinkDirectoryStatic(writeReroute.fileName(), lpNewFileName, flags);
+        }
+        else
+          writeReroute.insertMapping(WRITE_CONTEXT());
       }
     }
 
@@ -1475,10 +1481,13 @@ BOOL WINAPI usvfs::hook_MoveFileExW(LPCWSTR lpExistingFileName,
       readReroute.removeMapping(READ_CONTEXT(), isDirectory);
 
       if (writeReroute.newReroute()) {
-        spdlog::get("usvfs")->debug("The call was rerouted.");
-        if (isDirectory)
-          spdlog::get("usvfs")->debug("It's a directory!");
-        writeReroute.insertMapping(WRITE_CONTEXT(), isDirectory);
+        if (isDirectory) {
+          unsigned int flags = LINKFLAG_RECURSIVE;
+          if (writeReroute.newReroute()) flags |= LINKFLAG_CREATETARGET;
+          VirtualLinkDirectoryStatic(writeReroute.fileName(), lpNewFileName, flags);
+        }
+        else
+          writeReroute.insertMapping(WRITE_CONTEXT());
       }
     }
 
@@ -1588,7 +1597,13 @@ BOOL WINAPI usvfs::hook_MoveFileWithProgressW(LPCWSTR lpExistingFileName, LPCWST
     readReroute.removeMapping(READ_CONTEXT(), isDirectory);
 
     if (writeReroute.newReroute()) {
-      writeReroute.insertMapping(WRITE_CONTEXT(), isDirectory);
+      if (isDirectory) {
+        unsigned int flags = LINKFLAG_RECURSIVE;
+        if (writeReroute.newReroute()) flags |= LINKFLAG_CREATETARGET;
+        VirtualLinkDirectoryStatic(writeReroute.fileName(), lpNewFileName, flags);
+      }
+      else
+        writeReroute.insertMapping(WRITE_CONTEXT());
     }
   }
 

--- a/src/usvfs_dll/hooks/ntdll.cpp
+++ b/src/usvfs_dll/hooks/ntdll.cpp
@@ -591,6 +591,8 @@ void gatherVirtualEntries(const UnicodeString &dirName,
                                           FileName->Buffer, ush::CodePage::UTF8)
                                     : "*.*";
 
+    boost::replace_all(searchPattern, "\"", ".");
+
     for (const auto &subNode : node->find(searchPattern)) {
       if (((subNode->data().linkTarget.length() > 0) || subNode->isDirectory())
           && !subNode->hasFlag(usvfs::shared::FLAG_DUMMY)) {


### PR DESCRIPTION
* Detect cross-drive directory moves and use an alternate (working) method
* Recursively add new directories to the VFS
* Fix up returned errors with moves
* Allow moved files to be placed back in the same location
* Fix up handling of FFF / ntQDF search strings and correctly reroute based on valid non-search path
* Fix up FFF handling of relative paths
* Fix up ntQDF hook problem with dot characters represented as " when passed in
* Use the calculated Temp path for the FFF hook exclusion