### PR TITLE
Fix for WB file in use and xEdit renaming fail.

### DIFF
--- a/src/shared/directory_tree.h
+++ b/src/shared/directory_tree.h
@@ -452,6 +452,11 @@ public:
       if (self != par->m_Nodes.end()) {
         par->erase(self);
       }
+      else {
+        //trying to remove a node that des not exist, most likely because it was already removed in a lower level call. 
+        //this is known to happen when MoveFile has the MOVEFILE_COPY_ALLOWED flag and moving a mapped file.
+        spdlog::get("usvfs")->warn("Failed to remove inexisting node from tree: {}", m_Name.c_str());
+      }
     }
   }
 

--- a/src/shared/directory_tree.h
+++ b/src/shared/directory_tree.h
@@ -449,7 +449,9 @@ public:
     if (auto par = parent()) {
       spdlog::get("usvfs")->info("remove from tree {}", m_Name.c_str());
       auto self = par->m_Nodes.find(m_Name.c_str());
-      par->erase(self);
+      if (self != par->m_Nodes.end()) {
+        par->erase(self);
+      }
     }
   }
 

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -139,6 +139,7 @@ HMODULE WINAPI usvfs::hook_LoadLibraryExW(LPCWSTR lpFileName, HANDLE hFile,
   HMODULE res = nullptr;
 
   HOOK_START_GROUP(MutExHookGroup::LOAD_LIBRARY)
+  // Why is the usual if (!callContext.active()... check missing?
 
   RerouteW reroute = RerouteW::create(READ_CONTEXT(), callContext, lpFileName);
   PRE_REALCALL
@@ -488,6 +489,7 @@ DWORD WINAPI usvfs::hook_SetFileAttributesW(
   DWORD res = 0UL;
 
   HOOK_START_GROUP(MutExHookGroup::FILE_ATTRIBUTES)
+  // Why is the usual if (!callContext.active()... check missing?
 
   RerouteW reroute = RerouteW::create(READ_CONTEXT(), callContext, lpFileName);
   PRE_REALCALL
@@ -508,6 +510,7 @@ BOOL WINAPI usvfs::hook_DeleteFileW(LPCWSTR lpFileName)
   BOOL res = FALSE;
 
   HOOK_START_GROUP(MutExHookGroup::DELETE_FILE)
+  // Why is the usual if (!callContext.active()... check missing?
 
   RerouteW reroute = RerouteW::create(READ_CONTEXT(), callContext, lpFileName);
 
@@ -800,6 +803,9 @@ BOOL WINAPI usvfs::hook_MoveFileWithProgressA(LPCSTR lpExistingFileName, LPCSTR 
 
 BOOL WINAPI usvfs::hook_MoveFileWithProgressW(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName, LPPROGRESS_ROUTINE lpProgressRoutine, LPVOID lpData, DWORD dwFlags)
 {
+
+  //TODO: Remove all redundant hooks to moveFile alternatives.
+  //it would appear that all other moveFile functions end up calling this one with no additional code.
   BOOL res = FALSE;
 
   HOOK_START_GROUP(MutExHookGroup::SHELL_FILEOP)
@@ -861,7 +867,9 @@ BOOL WINAPI usvfs::hook_MoveFileWithProgressW(LPCWSTR lpExistingFileName, LPCWST
   writeReroute.updateResult(callContext, res);
 
   if (res) {
-    readReroute.removeMapping(READ_CONTEXT(), isDirectory); // Updating the rerouteCreate to check deleted file entries should make this okay
+    //TODO: this call causes the node to be removed twice in case of MOVEFILE_COPY_ALLOWED as the deleteFile hook lower level already takes care of it,
+    //but deleteFile can't be disabled since we are relying on it in case of MOVEFILE_REPLACE_EXISTING for the destination file. 
+    readReroute.removeMapping(READ_CONTEXT(), isDirectory); // Updating the rerouteCreate to check deleted file entries should make this okay (not related to comments above)
 
     if (writeReroute.newReroute()) {
       if (isDirectory)
@@ -1094,6 +1102,7 @@ DLLEXPORT BOOL WINAPI usvfs::hook_RemoveDirectoryW(
   BOOL res = FALSE;
 
   HOOK_START_GROUP(MutExHookGroup::DELETE_FILE)
+  // Why is the usual if (!callContext.active()... check missing?
 
   RerouteW reroute = RerouteW::create(READ_CONTEXT(), callContext, lpPathName);
 

--- a/src/usvfs_dll/hooks/ntdll.cpp
+++ b/src/usvfs_dll/hooks/ntdll.cpp
@@ -1075,6 +1075,7 @@ NTSTATUS ntdll_mess_NtOpenFile(PHANDLE FileHandle,
   NTSTATUS res = STATUS_NO_SUCH_FILE;
 
   HOOK_START_GROUP(MutExHookGroup::OPEN_FILE)
+  // Why is the usual if (!callContext.active()... check missing?
 
   bool storePath = false;
   if (((OpenOptions & FILE_DIRECTORY_FILE) != 0UL)
@@ -1344,6 +1345,7 @@ NTSTATUS WINAPI usvfs::hook_NtQueryAttributesFile(
   NTSTATUS res = STATUS_SUCCESS;
 
   HOOK_START_GROUP(MutExHookGroup::FILE_ATTRIBUTES)
+  // Why is the usual if (!callContext.active()... check missing?
 
   UnicodeString inPath = CreateUnicodeString(ObjectAttributes);
 

--- a/src/usvfs_dll/hooks/ntdll.cpp
+++ b/src/usvfs_dll/hooks/ntdll.cpp
@@ -1299,6 +1299,10 @@ NTSTATUS WINAPI usvfs::hook_NtClose(HANDLE Handle)
 //      std::lock_guard<std::recursive_mutex> lock(activeSearches.queryMutex);
       auto iter = activeSearches.info.find(Handle);
       if (iter != activeSearches.info.end()) {
+        if (iter->second.currentSearchHandle != INVALID_HANDLE_VALUE) {
+          ::CloseHandle(iter->second.currentSearchHandle);
+        }
+
         activeSearches.info.erase(iter);
         log = true;
       }


### PR DESCRIPTION
The problem with WB file in use was with a handle opened by FindFirstFile was getting leaked in case ntQueryDirecoryFile was not called until STATUS_NO_MORE_FILES, as the structure containing the pointer to the handle was erased before getting closed.

The problem with xEdit not being able to rename files (save the working copy) was due to MoveFile hook removing the source file twice from the directory tree in case the move was across drives (overwrite and Data on different drives when cleaning downguard) . In case of different drives MoveFile internally useses copy + delete, problem is that both the MoveFile hook and the DeleteFile hook removed the file from mapping. This fix does not actually resolve this, simply makes it so that removing a file that does no longer exist in the mapping does not crash usvfs. I also added a log line to keep track of occasions in which usvfs tries to remove files that are no longer in the mappings.

To properly address the above issue the code should be refactored to make it so that the moveFile hook does not remove the source file from the mappings if MOVEFILE_COPY_ALLOWED and source is rerouted.
Problem with that is that there are currently 5 different hooks for moveFile functions while in theory just MoveFileWithProgressW should suffice as it should be getting called directly by the other functions with only some char types conversions and no additional code.
