### PR TITLE
Delay parameter

### DIFF
--- a/include/usvfs.h
+++ b/include/usvfs.h
@@ -176,7 +176,8 @@ DLLEXPORT void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                           bool debugMode,
                                           LogLevel logLevel,
                                           CrashDumpsType crashDumpsType,
-                                          const char *crashDumpsPath);
+                                          const char *crashDumpsPath,
+                                          std::chrono::milliseconds delayProcess={});
 
 DLLEXPORT int WINAPI CreateMiniDump(PEXCEPTION_POINTERS exceptionPtrs, CrashDumpsType type, const wchar_t* dumpPath);
 

--- a/include/usvfsparameters.h
+++ b/include/usvfsparameters.h
@@ -22,6 +22,7 @@ along with usvfs. If not, see <http://www.gnu.org/licenses/>.
 
 #include "logging.h"
 #include "dllimport.h"
+#include <chrono>
 
 enum class CrashDumpsType : uint8_t {
   None,
@@ -40,6 +41,7 @@ struct USVFSParameters {
   LogLevel logLevel{LogLevel::Debug};
   CrashDumpsType crashDumpsType{CrashDumpsType::None};
   char crashDumpsPath[260];
+  std::chrono::milliseconds delayProcess{0};
 };
 
 }

--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -327,6 +327,10 @@ void __cdecl InitHooks(LPVOID parameters, size_t)
   usvfs_dump_type = params->crashDumpsType;
   usvfs_dump_path = ush::string_cast<std::wstring>(params->crashDumpsPath, ush::CodePage::UTF8);
 
+  if (params->delayProcess.count() > 0) {
+    ::Sleep(static_cast<unsigned long>(params->delayProcess.count()));
+  }
+
   SetLogLevel(params->logLevel);
 
   if (exceptionHandler == nullptr) {
@@ -775,11 +779,14 @@ void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                 const char *instanceName, bool debugMode,
                                 LogLevel logLevel,
                                 CrashDumpsType crashDumpsType,
-                                const char *crashDumpsPath)
+                                const char *crashDumpsPath,
+                                std::chrono::milliseconds delayProcess)
 {
   parameters->debugMode = debugMode;
   parameters->logLevel = logLevel;
   parameters->crashDumpsType = crashDumpsType;
+  parameters->delayProcess = delayProcess;
+
   strncpy_s(parameters->instanceName, instanceName, _TRUNCATE);
   if (crashDumpsPath && *crashDumpsPath && strlen(crashDumpsPath) < _countof(parameters->crashDumpsPath)) {
     memcpy(parameters->crashDumpsPath, crashDumpsPath, strlen(crashDumpsPath)+1);


### PR DESCRIPTION
This adds a parameter to `USVFSInitParameters()` to add a `Sleep()` call before the hooked process is resumed. It is 0 by default. When set to something like 10 seconds, it gives time to attach a debugger to the hooked process before it actually starts.

It's currently unused by MO, but I plan to add a setting in the ini, and perhaps a widget in the Diagnostics tab.