### PR TITLE
Propagate the delay parameter to the spawned process

### DIFF
--- a/src/usvfs_dll/hookcontext.cpp
+++ b/src/usvfs_dll/hookcontext.cpp
@@ -63,7 +63,8 @@ USVFSParameters SharedParameters::makeLocal() const
                          currentSHMName.c_str(),
                          currentInverseSHMName.c_str(),
                          debugMode, logLevel, crashDumpsType,
-                         crashDumpsPath.c_str());
+                         crashDumpsPath.c_str(),
+                         delayProcess);
   return result;
 }
 
@@ -75,11 +76,13 @@ void usvfs::USVFSInitParametersInt(USVFSParameters *parameters,
                                    bool debugMode,
                                    LogLevel logLevel,
                                    CrashDumpsType crashDumpsType,
-                                   const char *crashDumpsPath)
+                                   const char *crashDumpsPath,
+                                   std::chrono::milliseconds delayProcess)
 {
   parameters->debugMode = debugMode;
   parameters->logLevel = logLevel;
   parameters->crashDumpsType = crashDumpsType;
+  parameters->delayProcess = delayProcess;
   strncpy_s(parameters->instanceName, instanceName, _TRUNCATE);
   strncpy_s(parameters->currentSHMName, currentSHMName, _TRUNCATE);
   strncpy_s(parameters->currentInverseSHMName, currentInverseSHMName, _TRUNCATE);

--- a/src/usvfs_dll/hookcontext.h
+++ b/src/usvfs_dll/hookcontext.h
@@ -49,7 +49,8 @@ void USVFSInitParametersInt(USVFSParameters *parameters,
                             bool debugMode,
                             LogLevel logLevel,
                             CrashDumpsType crashDumpsType,
-                            const char *crashDumpsPath);
+                            const char *crashDumpsPath,
+                            std::chrono::milliseconds delayProcess);
 
 
 typedef shared::VoidAllocatorT::rebind<DWORD>::other DWORDAllocatorT;
@@ -86,6 +87,7 @@ struct SharedParameters {
     , logLevel(reference.logLevel)
     , crashDumpsType(reference.crashDumpsType)
     , crashDumpsPath(reference.crashDumpsPath, allocator)
+    , delayProcess(reference.delayProcess)
     , userCount(1)
     , processBlacklist(allocator)
     , processList(allocator)
@@ -102,6 +104,7 @@ struct SharedParameters {
   LogLevel logLevel;
   CrashDumpsType crashDumpsType;
   shared::StringT crashDumpsPath;
+  std::chrono::milliseconds delayProcess;
   uint32_t userCount;
   boost::container::flat_set<shared::StringT, std::less<shared::StringT>,
                              StringAllocatorT> processBlacklist;


### PR DESCRIPTION
Turns out parameters are copied to the spawned process and the delay process setting wasn't.