### PR TITLE
New parameters structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 *.vcxproj.user
 msbuild.log
 
+/stderr.log
+/stderr_32.log
+/stdout.log
+/stdout_32.log

--- a/include/usvfs.h
+++ b/include/usvfs.h
@@ -80,13 +80,19 @@ DLLEXPORT BOOL WINAPI VirtualLinkDirectoryStatic(LPCWSTR source, LPCWSTR destina
  * connect to a virtual filesystem as a controller, without hooking the calling process. Please note that
  * you can only be connected to one vfs, so this will silently disconnect from a previous vfs.
  */
+[[deprecated("deprecated, use usvfsConnectVFS()")]]
 DLLEXPORT BOOL WINAPI ConnectVFS(const USVFSParameters *parameters);
+
+DLLEXPORT BOOL WINAPI usvfsConnectVFS(const usvfsParameters* p);
 
 /**
  * @brief create a new VFS. This is similar to ConnectVFS except it guarantees
  *   the vfs is reset before use.
  */
+[[deprecated("deprecated, use usvfsCreateVFS()")]]
 DLLEXPORT BOOL WINAPI CreateVFS(const USVFSParameters *parameters);
+
+DLLEXPORT BOOL WINAPI usvfsCreateVFS(const usvfsParameters* p);
 
 /**
  * disconnect from a virtual filesystem. This removes hooks if necessary
@@ -116,11 +122,6 @@ DLLEXPORT BOOL WINAPI CreateProcessHooked(
  * FIXME retrieves log messages from all instances, the logging queue is not separated
  */
 DLLEXPORT bool WINAPI GetLogMessages(LPSTR buffer, size_t size, bool blocking = false);
-
-/**
- * @brief Used to change parameters which can be changed in runtime
- */
-DLLEXPORT void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type);
 
 /**
  * retrieves a readable representation of the vfs tree
@@ -170,14 +171,24 @@ DLLEXPORT void WINAPI InitLogging(bool toLocal = false);
  */
 DLLEXPORT void __cdecl InitHooks(LPVOID userData, size_t userDataSize);
 
-
+[[deprecated("deprecated, use usvfsCreateParameters()")]]
 DLLEXPORT void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                           const char *instanceName,
                                           bool debugMode,
                                           LogLevel logLevel,
                                           CrashDumpsType crashDumpsType,
-                                          const char *crashDumpsPath,
-                                          std::chrono::milliseconds delayProcess={});
+                                          const char *crashDumpsPath);
+
+/**
+* @brief Used to change parameters which can be changed in runtime
+*/
+[[deprecated("deprecated, use usvfsUpdateParameters()")]]
+DLLEXPORT void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type);
+
+// the only information used from the parameters are the crash dump type, log
+// level and process delay
+//
+DLLEXPORT void WINAPI usvfsUpdateParameters(usvfsParameters* p);
 
 DLLEXPORT int WINAPI CreateMiniDump(PEXCEPTION_POINTERS exceptionPtrs, CrashDumpsType type, const wchar_t* dumpPath);
 

--- a/include/usvfsparameters.h
+++ b/include/usvfsparameters.h
@@ -31,8 +31,11 @@ enum class CrashDumpsType : uint8_t {
   Full
 };
 
-extern "C" {
+extern "C"
+{
 
+// deprecated, use usvfsParameters and usvfsCreateParameters()
+//
 struct USVFSParameters {
   char instanceName[65];
   char currentSHMName[65];
@@ -41,7 +44,21 @@ struct USVFSParameters {
   LogLevel logLevel{LogLevel::Debug};
   CrashDumpsType crashDumpsType{CrashDumpsType::None};
   char crashDumpsPath[260];
-  std::chrono::milliseconds delayProcess{0};
 };
+
+
+struct usvfsParameters;
+
+DLLEXPORT usvfsParameters* usvfsCreateParameters();
+DLLEXPORT usvfsParameters* usvfsDupeParameters(usvfsParameters* p);
+DLLEXPORT void usvfsCopyParameters(const usvfsParameters* source, usvfsParameters* dest);
+DLLEXPORT void usvfsFreeParameters(usvfsParameters* p);
+
+DLLEXPORT void usvfsSetInstanceName(usvfsParameters* p, const char* name);
+DLLEXPORT void usvfsSetDebugMode(usvfsParameters* p, BOOL debugMode);
+DLLEXPORT void usvfsSetLogLevel(usvfsParameters* p, LogLevel level);
+DLLEXPORT void usvfsSetCrashDumpType(usvfsParameters* p, CrashDumpsType type);
+DLLEXPORT void usvfsSetCrashDumpPath(usvfsParameters* p, const char* path);
+DLLEXPORT void usvfsSetProcessDelay(usvfsParameters* p, int milliseconds);
 
 }

--- a/include/usvfsparametersprivate.h
+++ b/include/usvfsparametersprivate.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "usvfsparameters.h"
+
+struct usvfsParameters
+{
+  char instanceName[65];
+  char currentSHMName[65];
+  char currentInverseSHMName[65];
+  bool debugMode;
+  LogLevel logLevel{LogLevel::Debug};
+  CrashDumpsType crashDumpsType{CrashDumpsType::None};
+  char crashDumpsPath[260];
+  int delayProcessMs;
+
+  usvfsParameters();
+  usvfsParameters(const usvfsParameters&) = default;
+  usvfsParameters& operator=(const usvfsParameters&) = default;
+
+  usvfsParameters(
+    const char* instanceName,
+    const char* currentSHMName,
+    const char* currentInverseSHMName,
+    bool debugMode,
+    LogLevel logLevel,
+    CrashDumpsType crashDumpsType,
+    const char* crashDumpsPath,
+    int delayProcessMs);
+
+  usvfsParameters(const USVFSParameters& oldParams);
+
+  void setInstanceName(const char* name);
+  void setDebugMode(bool debugMode);
+  void setLogLevel(LogLevel level);
+  void setCrashDumpType(CrashDumpsType type);
+  void setCrashDumpPath(const char* path);
+  void setProcessDelay(int milliseconds);
+};

--- a/src/usvfs_dll/hookmanager.cpp
+++ b/src/usvfs_dll/hookmanager.cpp
@@ -46,7 +46,7 @@ namespace usvfs {
 HookManager *HookManager::s_Instance = nullptr;
 
 
-HookManager::HookManager(const USVFSParameters &params, HMODULE module)
+HookManager::HookManager(const usvfsParameters& params, HMODULE module)
   : m_Context(params, module)
 {
   if (s_Instance != nullptr) {

--- a/src/usvfs_dll/hookmanager.h
+++ b/src/usvfs_dll/hookmanager.h
@@ -32,7 +32,7 @@ class HookManager
 {
 public:
 
-  HookManager(const USVFSParameters &params, HMODULE module);
+  HookManager(const usvfsParameters& params, HMODULE module);
   ~HookManager();
 
   HookManager(const HookManager &reference) = delete;

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -226,7 +226,7 @@ BOOL WINAPI usvfs::hook_CreateProcessInternalW(
   LPWSTR cend = nullptr;
 
   std::wstring dllPath;
-  USVFSParameters callParameters;
+  usvfsParameters callParameters;
 
   { // scope for context lock
     auto context = READ_CONTEXT();

--- a/src/usvfs_dll/usvfsparameters.cpp
+++ b/src/usvfs_dll/usvfsparameters.cpp
@@ -1,0 +1,165 @@
+#include "usvfsparametersprivate.h"
+#include <algorithm>
+
+usvfsParameters::usvfsParameters() :
+  debugMode(false), logLevel(LogLevel::Debug),
+  crashDumpsType(CrashDumpsType::None), delayProcessMs(0)
+{
+  std::fill(std::begin(instanceName), std::end(instanceName), 0);
+  std::fill(std::begin(currentSHMName), std::end(currentSHMName), 0);
+  std::fill(std::begin(currentInverseSHMName), std::end(currentInverseSHMName), 0);
+  std::fill(std::begin(crashDumpsPath), std::end(crashDumpsPath), 0);
+}
+
+usvfsParameters::usvfsParameters(
+  const char *instanceName,
+  const char *currentSHMName,
+  const char *currentInverseSHMName,
+  bool debugMode,
+  LogLevel logLevel,
+  CrashDumpsType crashDumpsType,
+  const char *crashDumpsPath,
+  int delayProcessMs)
+  : usvfsParameters()
+{
+  strncpy_s(this->instanceName, instanceName, _TRUNCATE);
+  strncpy_s(this->currentSHMName, currentSHMName, _TRUNCATE);
+  strncpy_s(this->currentInverseSHMName, currentInverseSHMName, _TRUNCATE);
+  this->debugMode = debugMode;
+  this->logLevel = logLevel;
+  this->crashDumpsType = crashDumpsType;
+  strncpy_s(this->crashDumpsPath, crashDumpsPath, _TRUNCATE);
+  this->delayProcessMs = delayProcessMs;
+}
+
+usvfsParameters::usvfsParameters(const USVFSParameters& oldParams) :
+  usvfsParameters(
+    oldParams.instanceName,
+    oldParams.currentSHMName,
+    oldParams.currentInverseSHMName,
+    oldParams.debugMode,
+    oldParams.logLevel,
+    oldParams.crashDumpsType,
+    oldParams.crashDumpsPath,
+    0)
+{
+}
+
+void usvfsParameters::setInstanceName(const char* name)
+{
+  strncpy_s(instanceName, name, _TRUNCATE);
+  strncpy_s(currentSHMName, 60, name, _TRUNCATE);
+  memset(currentInverseSHMName, '\0', _countof(currentInverseSHMName));
+  _snprintf(currentInverseSHMName, 60, "inv_%s", name);
+}
+
+void usvfsParameters::setDebugMode(bool b)
+{
+  debugMode = b;
+}
+
+void usvfsParameters::setLogLevel(LogLevel level)
+{
+  logLevel = level;
+}
+
+void usvfsParameters::setCrashDumpType(CrashDumpsType type)
+{
+  crashDumpsType = type;
+}
+
+void usvfsParameters::setCrashDumpPath(const char* path)
+{
+  if (path && *path && strlen(path) < _countof(crashDumpsPath)) {
+    memcpy(crashDumpsPath, path, strlen(path)+1);
+  } else {
+    // crashDumpsPath invalid or overflow of USVFSParameters variable so disable
+    // crash dumps:
+    crashDumpsPath[0] = 0;
+    crashDumpsType = CrashDumpsType::None;
+  }
+}
+
+void usvfsParameters::setProcessDelay(int milliseconds)
+{
+  delayProcessMs = milliseconds;
+}
+
+
+extern "C"
+{
+
+usvfsParameters* usvfsCreateParameters()
+{
+  return new (std::nothrow) usvfsParameters;
+}
+
+usvfsParameters* usvfsDupeParameters(usvfsParameters* p)
+{
+  if (!p) {
+    return nullptr;
+  }
+
+  auto* dupe = usvfsCreateParameters();
+  if (!dupe) {
+    return nullptr;
+  }
+
+  *dupe = *p;
+
+  return dupe;
+}
+
+void usvfsCopyParameters(const usvfsParameters* source, usvfsParameters* dest)
+{
+  *dest = *source;
+}
+
+void usvfsFreeParameters(usvfsParameters* p)
+{
+  delete p;
+}
+
+void usvfsSetInstanceName(usvfsParameters* p, const char* name)
+{
+  if (p) {
+    p->setInstanceName(name);
+  }
+}
+
+void usvfsSetDebugMode(usvfsParameters* p, BOOL debugMode)
+{
+  if (p) {
+    p->setDebugMode(debugMode);
+  }
+}
+
+void usvfsSetLogLevel(usvfsParameters* p, LogLevel level)
+{
+  if (p) {
+    p->setLogLevel(level);
+  }
+}
+
+void usvfsSetCrashDumpType(usvfsParameters* p, CrashDumpsType type)
+{
+  if (p) {
+    p->setCrashDumpType(type);
+  }
+}
+
+void usvfsSetCrashDumpPath(usvfsParameters* p, const char* path)
+{
+  if (p) {
+    p->setCrashDumpPath(path);
+  }
+}
+
+void usvfsSetProcessDelay(usvfsParameters* p, int milliseconds)
+{
+  if (p) {
+    p->setProcessDelay(milliseconds);
+  }
+}
+
+} // extern "C"

--- a/src/usvfs_helper/inject.cpp
+++ b/src/usvfs_helper/inject.cpp
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with usvfs. If not, see <http://www.gnu.org/licenses/>.
 */
 #include "inject.h"
+#include "usvfsparametersprivate.h"
 #include <winapi.h>
 #include <exceptionex.h>
 #include <loghelpers.h>
@@ -36,14 +37,14 @@ namespace ush = usvfs::shared;
 using namespace winapi;
 
 void usvfs::injectProcess(const std::wstring &applicationPath
-                          , const USVFSParameters &parameters
+                          , const usvfsParameters &parameters
                           , const PROCESS_INFORMATION &processInfo)
 {
   injectProcess(applicationPath, parameters, processInfo.hProcess, processInfo.hThread);
 }
 
 void usvfs::injectProcess(const std::wstring &applicationPath
-                          , const USVFSParameters &parameters
+                          , const usvfsParameters &parameters
                           , HANDLE processHandle
                           , HANDLE threadHandle)
 {
@@ -106,7 +107,7 @@ void usvfs::injectProcess(const std::wstring &applicationPath
     spdlog::get("usvfs")->info("dll path: {}", log::wrap(dllPath.wstring()));
 
     InjectLib::InjectDLL(processHandle, threadHandle, dllPath.c_str(),
-                         "InitHooks", &parameters, sizeof(USVFSParameters));
+                         "InitHooks", &parameters, sizeof(parameters));
 
     spdlog::get("usvfs")->info("injection to same bitness process {} successful", ::GetProcessId(processHandle));
   } else {

--- a/src/usvfs_helper/inject.h
+++ b/src/usvfs_helper/inject.h
@@ -33,7 +33,7 @@ namespace usvfs {
  * @param processInfo
  */
 void injectProcess(const std::wstring &applicationPath
-                   , const USVFSParameters &parameters
+                   , const usvfsParameters &parameters
                    , const PROCESS_INFORMATION &processInfo);
 
 /**
@@ -45,7 +45,7 @@ void injectProcess(const std::wstring &applicationPath
  *               a new thread is created in the process
  */
 void injectProcess(const std::wstring &applicationPath
-                   , const USVFSParameters &parameters
+                   , const usvfsParameters &parameters
                    , HANDLE process, HANDLE thread);
 
 }

--- a/src/usvfs_proxy/main.cpp
+++ b/src/usvfs_proxy/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
       return 1;
     }
 
-    USVFSParameters par = params.first->makeLocal();
+    usvfsParameters par = params.first->makeLocal();
 
     boost::filesystem::path p(winapi::wide::getModuleFileName(nullptr));
 

--- a/src/usvfs_proxy/version.rc
+++ b/src/usvfs_proxy/version.rc
@@ -22,7 +22,7 @@ BEGIN
     BEGIN
       VALUE "FileVersion", VER_FILEVERSION_STR
       VALUE "CompanyName", "Mod Organizer 2 Team\0"
-      VALUE "FileDescription",  "USVFS\0"
+      VALUE "FileDescription",  "USVFS Proxy\0"
 #ifdef _WIN64
       VALUE "OriginalFilename", "usvfs_proxy_x64.exe\0"
 #else

--- a/vsbuild/usvfs_dll.vcxproj
+++ b/vsbuild/usvfs_dll.vcxproj
@@ -214,12 +214,14 @@
     <ClCompile Include="..\src\usvfs_dll\semaphore.cpp" />
     <ClCompile Include="..\src\usvfs_dll\stringcast_boost.cpp" />
     <ClCompile Include="..\src\usvfs_dll\usvfs.cpp" />
+    <ClCompile Include="..\src\usvfs_dll\usvfsparameters.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\dllimport.h" />
     <ClInclude Include="..\include\logging.h" />
     <ClInclude Include="..\include\usvfs.h" />
     <ClInclude Include="..\include\usvfsparameters.h" />
+    <ClInclude Include="..\include\usvfsparametersprivate.h" />
     <ClInclude Include="..\include\usvfs_version.h" />
     <ClInclude Include="..\src\usvfs_dll\hookcallcontext.h" />
     <ClInclude Include="..\src\usvfs_dll\hookcontext.h" />

--- a/vsbuild/usvfs_dll.vcxproj.filters
+++ b/vsbuild/usvfs_dll.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="..\src\usvfs_dll\semaphore.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\usvfs_dll\usvfsparameters.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\usvfs_dll\hooks\cogetserverpid.h">
@@ -105,6 +108,9 @@
     </ClInclude>
     <ClInclude Include="..\src\usvfs_dll\maptracker.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\usvfsparametersprivate.h">
+      <Filter>Header Files\include</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The problem this is trying to solve is that the old `USVSParameters` structure, `USVFSInitParameters()` and `USVFSUpdateParams()` can't be modified without breaking the ABI. I wanted to add the spawn delay parameter, but then the DLL wouldn't be compatible with 2.2.1. I don't want to pick and choose changes to release patches to usvfs.

This PR completely deprecates `USVSParameters` as well as its associated functions, and changes all the internals to use the new `usvfsParameters` instead. The two structures are basically identical (except for the new spawn delay), but `usvfsParameters` is not exposed, it's just an opaque pointer. It also starts a long-term process of adding the `usvfs` prefix to the public interface, because stuff like `GetLogMessages()` isn't great.

Specifically, these are deprecated:

- `ConnectVFS()`, replaced by `usvfsConnectVFS()`.
- `CreateVFS()`, replaced by `usvfsCreateVFS()`.
- `USVFSInitParameters()`, replaced by `usvfsCreateParameters()` and its associated functions.
- `USVFSUpdateParams()`, replaced by `usvfsUpdateParameters()`
- `USVSParameters` structure, replaced by `usvfsParameters`
- `CreateHookContext()`, replaced by `usvfsCreateHookContext()` (seems to be only used for internal tests)
