### PR TITLE
Protect shared parameters with a mutex

### DIFF
--- a/include/sharedparameters.h
+++ b/include/sharedparameters.h
@@ -86,6 +86,7 @@ private:
     ForcedLibrary, ForcedLibraryAllocatorT>;
 
 
+  mutable bi::interprocess_mutex m_mutex;
   shared::StringT m_instanceName;
   shared::StringT m_currentSHMName;
   shared::StringT m_currentInverseSHMName;

--- a/include/sharedparameters.h
+++ b/include/sharedparameters.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "usvfsparameters.h"
+#include "dllimport.h"
+#include <shared_memory.h>
+
+#include <string>
+#include <boost/interprocess/containers/string.hpp>
+#include <boost/interprocess/containers/flat_set.hpp>
+#include <boost/interprocess/containers/slist.hpp>
+
+namespace usvfs
+{
+
+class ForcedLibrary
+{
+public:
+  ForcedLibrary(
+    const std::string& processName, const std::string& libraryPath,
+    const shared::VoidAllocatorT &allocator);
+
+  std::string processName() const;
+  std::string libraryPath() const;
+
+private:
+  shared::StringT m_processName;
+  shared::StringT m_libraryPath;
+};
+
+
+class DLLEXPORT SharedParameters
+{
+public:
+  SharedParameters() = delete;
+  SharedParameters(const SharedParameters &reference) = delete;
+  SharedParameters &operator=(const SharedParameters &reference) = delete;
+
+  SharedParameters(const usvfsParameters& reference,
+    const shared::VoidAllocatorT &allocator);
+
+  usvfsParameters makeLocal() const;
+
+  std::string instanceName() const;
+  std::string currentSHMName() const;
+  std::string currentInverseSHMName() const;
+  void setSHMNames(const std::string& current, const std::string& inverse);
+
+  void setDebugParameters(
+    LogLevel level, CrashDumpsType dumpType, const std::string& dumpPath,
+    std::chrono::milliseconds delayProcess);
+
+  std::size_t userConnected();
+  std::size_t userDisconnected();
+  std::size_t userCount();
+
+  std::size_t registeredProcessCount() const;
+  std::vector<DWORD> registeredProcesses() const;
+  void registerProcess(DWORD pid);
+  void unregisterProcess(DWORD pid);
+
+  void blacklistExecutable(const std::string& name);
+  void clearExecutableBlacklist();
+  bool executableBlacklisted(const std::string& app, const std::string& cmd) const;
+
+  void addForcedLibrary(const std::string& process, const std::string& path);
+  std::vector<std::string> forcedLibraries(const std::string& processName);
+  void clearForcedLibraries();
+
+private:
+  using StringAllocatorT =
+    shared::VoidAllocatorT::rebind<shared::StringT>::other;
+
+  using DWORDAllocatorT = shared::VoidAllocatorT::rebind<DWORD>::other;
+
+  using ForcedLibraryAllocatorT =
+    shared::VoidAllocatorT::rebind<ForcedLibrary>::other;
+
+
+  using ProcessBlacklist = boost::container::flat_set<
+    shared::StringT, std::less<shared::StringT>, StringAllocatorT>;
+
+  using ProcessList = boost::container::flat_set<
+    DWORD, std::less<DWORD>, DWORDAllocatorT>;
+
+  using ForcedLibraries = boost::container::slist<
+    ForcedLibrary, ForcedLibraryAllocatorT>;
+
+
+  shared::StringT m_instanceName;
+  shared::StringT m_currentSHMName;
+  shared::StringT m_currentInverseSHMName;
+  bool m_debugMode;
+  LogLevel m_logLevel;
+  CrashDumpsType m_crashDumpsType;
+  shared::StringT m_crashDumpsPath;
+  std::chrono::milliseconds m_delayProcess;
+  uint32_t m_userCount;
+  ProcessBlacklist m_processBlacklist;
+  ProcessList m_processList;
+  ForcedLibraries m_forcedLibraries;
+};
+
+} // namespace

--- a/include/usvfs.h
+++ b/include/usvfs.h
@@ -185,8 +185,7 @@ DLLEXPORT void WINAPI USVFSInitParameters(USVFSParameters *parameters,
 [[deprecated("deprecated, use usvfsUpdateParameters()")]]
 DLLEXPORT void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type);
 
-// the only information used from the parameters are the crash dump type, log
-// level and process delay
+// the instance and shm names are not updated
 //
 DLLEXPORT void WINAPI usvfsUpdateParameters(usvfsParameters* p);
 

--- a/include/usvfsparameters.h
+++ b/include/usvfsparameters.h
@@ -61,4 +61,7 @@ DLLEXPORT void usvfsSetCrashDumpType(usvfsParameters* p, CrashDumpsType type);
 DLLEXPORT void usvfsSetCrashDumpPath(usvfsParameters* p, const char* path);
 DLLEXPORT void usvfsSetProcessDelay(usvfsParameters* p, int milliseconds);
 
+DLLEXPORT const char* usvfsLogLevelToString(LogLevel lv);
+DLLEXPORT const char* usvfsCrashDumpTypeToString(CrashDumpsType t);
+
 }

--- a/src/usvfs_dll/hookcontext.h
+++ b/src/usvfs_dll/hookcontext.h
@@ -175,7 +175,6 @@ private:
   static HookContext *s_Instance;
 
   shared::SharedMemoryT m_ConfigurationSHM;
-#pragma message("this should be protected by a system-wide named mutex")
   SharedParameters *m_Parameters{nullptr};
   RedirectionTreeContainer m_Tree;
   RedirectionTreeContainer m_InverseTree;

--- a/src/usvfs_dll/hookcontext.h
+++ b/src/usvfs_dll/hookcontext.h
@@ -32,9 +32,6 @@ along with usvfs. If not, see <http://www.gnu.org/licenses/>.
 #include <boost/filesystem/path.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/shared_lock_guard.hpp>
-#include <boost/interprocess/containers/string.hpp>
-#include <boost/interprocess/containers/flat_set.hpp>
-#include <boost/interprocess/containers/slist.hpp>
 #include <memory>
 #include <set>
 #include <future>
@@ -43,65 +40,7 @@ along with usvfs. If not, see <http://www.gnu.org/licenses/>.
 namespace usvfs
 {
 
-typedef shared::VoidAllocatorT::rebind<DWORD>::other DWORDAllocatorT;
-typedef shared::VoidAllocatorT::rebind<shared::StringT>::other StringAllocatorT;
-
-struct ForcedLibrary {
-  ForcedLibrary(const char *processName, const char *libraryPath,
-                const shared::VoidAllocatorT &allocator)
-    : processName(processName, allocator)
-    , libraryPath(libraryPath, allocator)
-  {
-  }
-
-  shared::StringT processName;
-  shared::StringT libraryPath;
-};
-
-typedef shared::VoidAllocatorT::rebind<ForcedLibrary>::other ForcedLibraryAllocatorT;
-
-struct SharedParameters {
-
-  SharedParameters() = delete;
-
-  SharedParameters(const SharedParameters &reference) = delete;
-
-  SharedParameters &operator=(const SharedParameters &reference) = delete;
-
-  SharedParameters(const usvfsParameters& reference,
-                   const shared::VoidAllocatorT &allocator)
-    : instanceName(reference.instanceName, allocator)
-    , currentSHMName(reference.currentSHMName, allocator)
-    , currentInverseSHMName(reference.currentInverseSHMName, allocator)
-    , debugMode(reference.debugMode)
-    , logLevel(reference.logLevel)
-    , crashDumpsType(reference.crashDumpsType)
-    , crashDumpsPath(reference.crashDumpsPath, allocator)
-    , delayProcess(reference.delayProcessMs)
-    , userCount(1)
-    , processBlacklist(allocator)
-    , processList(allocator)
-    , forcedLibraries(allocator)
-  {
-  }
-
-  DLLEXPORT usvfsParameters makeLocal() const;
-
-  shared::StringT instanceName;
-  shared::StringT currentSHMName;
-  shared::StringT currentInverseSHMName;
-  bool debugMode;
-  LogLevel logLevel;
-  CrashDumpsType crashDumpsType;
-  shared::StringT crashDumpsPath;
-  std::chrono::milliseconds delayProcess;
-  uint32_t userCount;
-  boost::container::flat_set<shared::StringT, std::less<shared::StringT>,
-                             StringAllocatorT> processBlacklist;
-  boost::container::flat_set<DWORD, std::less<DWORD>, DWORDAllocatorT> processList;
-  boost::container::slist<ForcedLibrary, ForcedLibraryAllocatorT> forcedLibraries;
-};
-
+class DLLEXPORT SharedParameters;
 
 /**
  * @brief context available to hooks. This is protected by a many-reader
@@ -216,9 +155,9 @@ public:
   void clearLibraryForceLoads();
   std::vector<std::wstring> librariesToForceLoad(const std::wstring &processName);
 
-  void setLogLevel(LogLevel level);
-  void setCrashDumpsType(CrashDumpsType type);
-  void setDelayProcess(std::chrono::milliseconds delay);
+  void setDebugParameters(
+    LogLevel level, CrashDumpsType dumpType, const std::string& dumpPath,
+    std::chrono::milliseconds delayProcess);
 
   void updateParameters() const;
 

--- a/src/usvfs_dll/sharedparameters.cpp
+++ b/src/usvfs_dll/sharedparameters.cpp
@@ -1,0 +1,194 @@
+#include <sharedparameters.h>
+#include <usvfsparametersprivate.h>
+#include <logging.h>
+#include <boost/algorithm/string/predicate.hpp>
+#include <spdlog.h>
+
+namespace usvfs
+{
+
+ForcedLibrary::ForcedLibrary(
+  const std::string& process, const std::string& path,
+  const shared::VoidAllocatorT& alloc) :
+  m_processName(process.begin(), process.end(), alloc),
+  m_libraryPath(path.begin(), path.end(), alloc)
+{
+}
+
+std::string ForcedLibrary::processName() const
+{
+  return {m_processName.begin(), m_processName.end()};
+}
+
+std::string ForcedLibrary::libraryPath() const
+{
+  return {m_libraryPath.begin(), m_libraryPath.end()};
+}
+
+
+SharedParameters::SharedParameters(const usvfsParameters& reference,
+  const shared::VoidAllocatorT &allocator)
+  : m_instanceName(reference.instanceName, allocator)
+  , m_currentSHMName(reference.currentSHMName, allocator)
+  , m_currentInverseSHMName(reference.currentInverseSHMName, allocator)
+  , m_debugMode(reference.debugMode)
+  , m_logLevel(reference.logLevel)
+  , m_crashDumpsType(reference.crashDumpsType)
+  , m_crashDumpsPath(reference.crashDumpsPath, allocator)
+  , m_delayProcess(reference.delayProcessMs)
+  , m_userCount(1)
+  , m_processBlacklist(allocator)
+  , m_processList(allocator)
+  , m_forcedLibraries(allocator)
+{
+}
+
+usvfsParameters SharedParameters::makeLocal() const
+{
+  return usvfsParameters(
+    m_instanceName.c_str(),
+    m_currentSHMName.c_str(),
+    m_currentInverseSHMName.c_str(),
+    m_debugMode, m_logLevel, m_crashDumpsType,
+    m_crashDumpsPath.c_str(),
+    m_delayProcess.count());
+}
+
+std::string SharedParameters::instanceName() const
+{
+  return {m_instanceName.begin(), m_instanceName.end()};
+}
+
+std::string SharedParameters::currentSHMName() const
+{
+  return {m_currentSHMName.begin(), m_currentSHMName.end()};
+}
+
+std::string SharedParameters::currentInverseSHMName() const
+{
+  return {m_currentInverseSHMName.begin(), m_currentInverseSHMName.end()};
+}
+
+void SharedParameters::setSHMNames(
+  const std::string& current, const std::string& inverse)
+{
+  m_currentSHMName.assign(current.begin(), current.end());
+  m_currentInverseSHMName.assign(inverse.begin(), inverse.end());
+}
+
+void SharedParameters::setDebugParameters(
+  LogLevel level, CrashDumpsType dumpType, const std::string& dumpPath,
+  std::chrono::milliseconds delayProcess)
+{
+  m_logLevel = level;
+  m_crashDumpsType = dumpType;
+  m_crashDumpsPath.assign(dumpPath.begin(), dumpPath.end());
+  m_delayProcess = delayProcess;
+}
+
+std::size_t SharedParameters::userConnected()
+{
+  return ++m_userCount;
+}
+
+std::size_t SharedParameters::userDisconnected()
+{
+  return --m_userCount;
+}
+
+std::size_t SharedParameters::userCount()
+{
+  return m_userCount;
+}
+
+std::size_t SharedParameters::registeredProcessCount() const
+{
+  return m_processList.size();
+}
+
+std::vector<DWORD> SharedParameters::registeredProcesses() const
+{
+  return {m_processList.begin(), m_processList.end()};
+}
+
+void SharedParameters::registerProcess(DWORD pid)
+{
+  m_processList.insert(pid);
+}
+
+void SharedParameters::unregisterProcess(DWORD pid)
+{
+  auto itor = m_processList.find(pid);
+
+  if (itor == m_processList.end()) {
+    spdlog::get("usvfs")->error(
+      "cannot unregister process {}, not in list", pid);
+
+    return;
+  }
+
+  m_processList.erase(itor);
+}
+
+void SharedParameters::blacklistExecutable(const std::string& name)
+{
+  m_processBlacklist.insert(shared::StringT(
+    name.begin(), name.end(), m_processBlacklist.get_allocator()));
+}
+
+void SharedParameters::clearExecutableBlacklist()
+{
+  m_processBlacklist.clear();
+}
+
+bool SharedParameters::executableBlacklisted(
+  const std::string& appName, const std::string& cmdLine) const
+{
+  for (const shared::StringT& sitem : m_processBlacklist) {
+    const auto item = "\\" + std::string(sitem.begin(), sitem.end());
+
+    if (!appName.empty()) {
+      if (boost::algorithm::iends_with(appName, item)) {
+        spdlog::get("usvfs")->info("application {} is blacklisted", appName);
+        return true;
+      }
+    }
+
+    if (!cmdLine.empty()) {
+      if (boost::algorithm::icontains(cmdLine, item)) {
+        spdlog::get("usvfs")->info("command line {} is blacklisted", cmdLine);
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+void SharedParameters::addForcedLibrary(
+  const std::string& processName, const std::string& libraryPath)
+{
+  m_forcedLibraries.push_front(ForcedLibrary(
+    processName, libraryPath, m_forcedLibraries.get_allocator()));
+}
+
+std::vector<std::string> SharedParameters::forcedLibraries(
+  const std::string& processName)
+{
+  std::vector<std::string> v;
+
+  for (const auto& lib : m_forcedLibraries) {
+    if (boost::algorithm::iequals(processName, lib.processName())) {
+      v.push_back(lib.libraryPath());
+    }
+  }
+
+  return v;
+}
+
+void SharedParameters::clearForcedLibraries()
+{
+  m_forcedLibraries.clear();
+}
+
+} // namespace

--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -184,14 +184,27 @@ void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type)
 
 void WINAPI usvfsUpdateParameters(usvfsParameters* p)
 {
+  spdlog::get("usvfs")->info(
+    "updating parameters:\n"
+    " . debugMode: {}\n"
+    " . log level: {}\n"
+    " . dump type: {}\n"
+    " . dump path: {}\n"
+    " . delay process: {}ms",
+    p->debugMode, usvfsLogLevelToString(p->logLevel),
+    usvfsCrashDumpTypeToString(p->crashDumpsType), p->crashDumpsPath,
+    p->delayProcessMs);
+
   // update actual values used:
   usvfs_dump_type = p->crashDumpsType;
+  usvfs_dump_path = ush::string_cast<std::wstring>(
+    p->crashDumpsPath, ush::CodePage::UTF8);
   SetLogLevel(p->logLevel);
 
   // update parameters in context so spawned process will inherit changes:
-  context->setLogLevel(p->logLevel);
-  context->setCrashDumpsType(p->crashDumpsType);
-  context->setDelayProcess(std::chrono::milliseconds(p->delayProcessMs));
+  context->setDebugParameters(
+    p->logLevel, p->crashDumpsType, p->crashDumpsPath,
+    std::chrono::milliseconds(p->delayProcessMs));
 }
 
 

--- a/src/usvfs_dll/usvfsparameters.cpp
+++ b/src/usvfs_dll/usvfsparameters.cpp
@@ -89,6 +89,49 @@ void usvfsParameters::setProcessDelay(int milliseconds)
 extern "C"
 {
 
+const char* usvfsLogLevelToString(LogLevel lv)
+{
+  switch (lv)
+  {
+    case LogLevel::Debug:
+      return "debug";
+
+    case LogLevel::Info:
+      return "info";
+
+    case LogLevel::Warning:
+      return "warning";
+
+    case LogLevel::Error:
+      return "error";
+
+    default:
+      return "unknown";
+  }
+}
+
+const char* usvfsCrashDumpTypeToString(CrashDumpsType t)
+{
+  switch (t)
+  {
+    case CrashDumpsType::None:
+      return "none";
+
+    case CrashDumpsType::Mini:
+      return "mini";
+
+    case CrashDumpsType::Data:
+      return "data";
+
+    case CrashDumpsType::Full:
+      return "full";
+
+    default:
+      return "unknown";
+  }
+}
+
+
 usvfsParameters* usvfsCreateParameters()
 {
   return new (std::nothrow) usvfsParameters;

--- a/vsbuild/usvfs_dll.vcxproj
+++ b/vsbuild/usvfs_dll.vcxproj
@@ -212,6 +212,7 @@
     <ClCompile Include="..\src\usvfs_dll\hooks\ntdll.cpp" />
     <ClCompile Include="..\src\usvfs_dll\redirectiontree.cpp" />
     <ClCompile Include="..\src\usvfs_dll\semaphore.cpp" />
+    <ClCompile Include="..\src\usvfs_dll\sharedparameters.cpp" />
     <ClCompile Include="..\src\usvfs_dll\stringcast_boost.cpp" />
     <ClCompile Include="..\src\usvfs_dll\usvfs.cpp" />
     <ClCompile Include="..\src\usvfs_dll\usvfsparameters.cpp" />
@@ -219,6 +220,7 @@
   <ItemGroup>
     <ClInclude Include="..\include\dllimport.h" />
     <ClInclude Include="..\include\logging.h" />
+    <ClInclude Include="..\include\sharedparameters.h" />
     <ClInclude Include="..\include\usvfs.h" />
     <ClInclude Include="..\include\usvfsparameters.h" />
     <ClInclude Include="..\include\usvfsparametersprivate.h" />

--- a/vsbuild/usvfs_dll.vcxproj.filters
+++ b/vsbuild/usvfs_dll.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClCompile Include="..\src\usvfs_dll\usvfsparameters.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\usvfs_dll\sharedparameters.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\usvfs_dll\hooks\cogetserverpid.h">
@@ -110,6 +113,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\usvfsparametersprivate.h">
+      <Filter>Header Files\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\sharedparameters.h">
       <Filter>Header Files\include</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
I had an intermittent crash when checking if an executable is blacklisted. My guess is that it was actually because the process list became corrupted, since it wasn't protected by a mutex. Multiple processes would add and remove themselves from that list without synchronization.

- I moved everything to `sharedparameters.h` and `sharedparameters.cpp`;
- I made all the fields private and added convenience functions to hide shared memory manipulations;
- I added a `m_mutex` that's locked for every operation.

I decided against using multiple mutexes because the only time the shared parameters are used is when settings change, or a process is started and terminated. I didn't feel like the added complexity was worth it.

Goes with https://github.com/ModOrganizer2/modorganizer/pull/885.