### PR TITLE
Optimizations

### DIFF
--- a/src/shared/directory_tree.cpp
+++ b/src/shared/directory_tree.cpp
@@ -41,4 +41,40 @@ void advanceIter(
     ++iter;
 }
 
+
+DecomposablePath::DecomposablePath(std::string_view s)
+  : m_s(s), m_begin(0), m_end(0)
+{
+  m_end = nextSeparator(m_begin);
+}
+
+bool DecomposablePath::last() const
+{
+  return (m_end >= m_s.size());
+}
+
+void DecomposablePath::next()
+{
+  m_begin = m_end + 1;
+  m_end = nextSeparator(m_begin);
+}
+
+std::string_view DecomposablePath::current() const
+{
+  return {m_s.data() + m_begin, m_end - m_begin};
+}
+
+std::size_t DecomposablePath::nextSeparator(std::size_t from) const
+{
+  while (from < m_s.size()) {
+    if (m_s[from] == '/' || m_s[from] == '\\') {
+      break;
+    }
+
+    ++from;
+  }
+
+  return from;
+}
+
 }  // namespace

--- a/src/shared/directory_tree.cpp
+++ b/src/shared/directory_tree.cpp
@@ -41,40 +41,4 @@ void advanceIter(
     ++iter;
 }
 
-
-DecomposablePath::DecomposablePath(std::string_view s)
-  : m_s(s), m_begin(0), m_end(0)
-{
-  m_end = nextSeparator(m_begin);
-}
-
-bool DecomposablePath::last() const
-{
-  return (m_end >= m_s.size());
-}
-
-void DecomposablePath::next()
-{
-  m_begin = m_end + 1;
-  m_end = nextSeparator(m_begin);
-}
-
-std::string_view DecomposablePath::current() const
-{
-  return {m_s.data() + m_begin, m_end - m_begin};
-}
-
-std::size_t DecomposablePath::nextSeparator(std::size_t from) const
-{
-  while (from < m_s.size()) {
-    if (m_s[from] == '/' || m_s[from] == '\\') {
-      break;
-    }
-
-    ++from;
-  }
-
-  return from;
-}
-
 }  // namespace

--- a/src/shared/directory_tree.h
+++ b/src/shared/directory_tree.h
@@ -60,26 +60,36 @@ fs::path::iterator nextIter(
 void advanceIter(fs::path::iterator &iter, const fs::path::iterator &end);
 
 
+// decomposes a path into its components
+//
 class DecomposablePath
 {
 public:
+  // the given string_view is not copied, it must stay alive
+  //
   explicit DecomposablePath(std::string_view s)
     : m_s(s), m_begin(0), m_end(0)
   {
     m_end = nextSeparator(m_begin);
   }
 
-  bool last() const
-  {
-    return (m_end >= m_s.size());
-  }
-
+  // move to the next component, undefined if last() is true
+  //
   void next()
   {
     m_begin = m_end + 1;
     m_end = nextSeparator(m_begin);
   }
 
+  // whether this is the last component
+  //
+  bool last() const
+  {
+    return (m_end >= m_s.size());
+  }
+
+  // the current component
+  //
   std::string_view current() const
   {
     return {m_s.data() + m_begin, m_end - m_begin};
@@ -89,6 +99,8 @@ private:
   std::string_view m_s;
   std::size_t m_begin, m_end;
 
+  // finds the next path separator
+  //
   std::size_t nextSeparator(std::size_t from) const
   {
     while (from < m_s.size()) {

--- a/src/shared/directory_tree.h
+++ b/src/shared/directory_tree.h
@@ -63,31 +63,17 @@ void advanceIter(fs::path::iterator &iter, const fs::path::iterator &end);
 class DecomposablePath
 {
 public:
-  explicit DecomposablePath(std::wstring_view s)
-    : m_path(s.begin(), s.end()), m_itor(m_path.begin()), m_string(m_itor->string())
-  {
-  }
+  explicit DecomposablePath(std::string_view s);
 
-  bool last() const
-  {
-    return (nextIter(m_itor, m_path.end()) == m_path.end());
-  }
-
-  void next()
-  {
-    m_itor = nextIter(m_itor, m_path.end());
-    m_string = m_itor->string();
-  }
-
-  std::string_view current() const
-  {
-    return m_string;
-  }
+  bool last() const;
+  void next();
+  std::string_view current() const;
 
 private:
-  fs::path m_path;
-  fs::path::iterator m_itor;
-  std::string m_string;
+  std::string_view m_s;
+  std::size_t m_begin, m_end;
+
+  std::size_t nextSeparator(std::size_t from) const;
 };
 
 

--- a/src/shared/directory_tree.h
+++ b/src/shared/directory_tree.h
@@ -63,17 +63,44 @@ void advanceIter(fs::path::iterator &iter, const fs::path::iterator &end);
 class DecomposablePath
 {
 public:
-  explicit DecomposablePath(std::string_view s);
+  explicit DecomposablePath(std::string_view s)
+    : m_s(s), m_begin(0), m_end(0)
+  {
+    m_end = nextSeparator(m_begin);
+  }
 
-  bool last() const;
-  void next();
-  std::string_view current() const;
+  bool last() const
+  {
+    return (m_end >= m_s.size());
+  }
+
+  void next()
+  {
+    m_begin = m_end + 1;
+    m_end = nextSeparator(m_begin);
+  }
+
+  std::string_view current() const
+  {
+    return {m_s.data() + m_begin, m_end - m_begin};
+  }
 
 private:
   std::string_view m_s;
   std::size_t m_begin, m_end;
 
-  std::size_t nextSeparator(std::size_t from) const;
+  std::size_t nextSeparator(std::size_t from) const
+  {
+    while (from < m_s.size()) {
+      if (m_s[from] == '/' || m_s[from] == '\\') {
+        break;
+      }
+
+      ++from;
+    }
+
+    return from;
+  }
 };
 
 

--- a/src/shared/tree_container.h
+++ b/src/shared/tree_container.h
@@ -238,8 +238,6 @@ private:
     const T &data, bool overwrite, unsigned int flags,
     const VoidAllocatorT &allocator)
   {
-    StringT iterString(path.current(), allocator);
-
     if (path.last()) {
       typename TreeT::NodePtrT newNode = base->node(path.current());
 
@@ -249,26 +247,26 @@ private:
         newNode = createSubPtr(node);
         newNode->m_Self = TreeT::WeakPtrT(newNode);
         newNode->m_Parent = base->m_Self;
-        base->set(std::move(iterString), newNode);
+        base->set(StringT(path.current(), allocator), newNode);
         return newNode;
       } else if (overwrite) {
         newNode->m_Data = createData<TreeT::DataT, T>(data, allocator);
         newNode->m_Flags = static_cast<usvfs::shared::TreeFlags>(flags);
         return newNode;
       } else {
-        auto res = base->m_Nodes.emplace(std::move(iterString), newNode);
+        auto res = base->m_Nodes.emplace(StringT(path.current(), allocator), newNode);
         return res.second ? newNode : TreeT::NodePtrT();
       }
     } else {
       // not last component, continue search in child node
-      auto subNode = base->m_Nodes.find(iterString);
+      auto subNode = base->m_Nodes.find(path.current());
 
       if (subNode == base->m_Nodes.end()) {
         typename TreeT::NodePtrT newNode = createSubPtr(createSubNode(
           allocator, path.current(),
           FLAG_DIRECTORY | FLAG_DUMMY, createEmpty()));
 
-        subNode = base->m_Nodes.emplace(std::move(iterString), newNode).first;
+        subNode = base->m_Nodes.emplace(StringT(path.current(), allocator), newNode).first;
         subNode->second->m_Self = TreeT::WeakPtrT(subNode->second);
         subNode->second->m_Parent = base->m_Self;
       }

--- a/src/shared/tree_container.h
+++ b/src/shared/tree_container.h
@@ -133,18 +133,20 @@ public:
     const fs::path &name, const T &data,
     TreeFlags flags = 0, bool overwrite = true)
   {
-    try
-    {
+    for (;;) {
       DecomposablePath dp(name.string());
 
-      return addNode(
-        m_TreeMeta->tree.get(), dp,
-        data, overwrite, flags, allocator());
-    }
-    catch (const bi::bad_alloc&)
-    {
+      try
+      {
+        return addNode(
+          m_TreeMeta->tree.get(), dp,
+          data, overwrite, flags, allocator());
+      }
+      catch (const bi::bad_alloc&)
+      {
+      }
+
       reassign();
-      return addFile(name, data, flags, overwrite);
     }
   }
 
@@ -162,18 +164,20 @@ public:
     const fs::path &name, const T &data,
     TreeFlags flags = 0, bool overwrite = true)
   {
-    try
-    {
+    for (;;) {
       DecomposablePath dp(name.string());
 
-      return addNode(
-        m_TreeMeta->tree.get(), dp, data,
-        overwrite, flags | FLAG_DIRECTORY, allocator());
-    }
-    catch (const bi::bad_alloc &)
-    {
+      try
+      {
+        return addNode(
+          m_TreeMeta->tree.get(), dp, data,
+          overwrite, flags | FLAG_DIRECTORY, allocator());
+      }
+      catch (const bi::bad_alloc &)
+      {
+      }
+
       reassign();
-      return addDirectory(name, data, flags, overwrite);
     }
   }
 

--- a/src/shared/tree_container.h
+++ b/src/shared/tree_container.h
@@ -241,7 +241,7 @@ private:
     if (path.last()) {
       typename TreeT::NodePtrT newNode = base->node(path.current());
 
-      if (newNode.get() == nullptr) {
+      if (!newNode) {
         // last name component, should be the filename
         TreeT *node = createSubNode(allocator, path.current(), flags, data);
         newNode = createSubPtr(node);
@@ -254,8 +254,8 @@ private:
         newNode->m_Flags = static_cast<usvfs::shared::TreeFlags>(flags);
         return newNode;
       } else {
-        auto res = base->m_Nodes.emplace(StringT(path.current(), allocator), newNode);
-        return res.second ? newNode : TreeT::NodePtrT();
+        // the node is already in the tree, overwrite is false, nothing to do
+        return {};
       }
     } else {
       // not last component, continue search in child node

--- a/src/shared/tree_container.h
+++ b/src/shared/tree_container.h
@@ -135,7 +135,7 @@ public:
   {
     try
     {
-      DecomposablePath dp(name.wstring());
+      DecomposablePath dp(name.string());
 
       return addNode(
         m_TreeMeta->tree.get(), dp,
@@ -164,7 +164,7 @@ public:
   {
     try
     {
-      DecomposablePath dp(name.wstring());
+      DecomposablePath dp(name.string());
 
       return addNode(
         m_TreeMeta->tree.get(), dp, data,


### PR DESCRIPTION
Some optimizations:
- Avoiding path iterators: `DecomposablePath` keeps a `string_view` and plays with indexes to decompose a path into its components.
- Faster extension check for the reverse tree: Since the extension of every file is checked, there's a new `extensionMatchesCI()` that compares extensions without memory allocation.
- Avoiding unnecessary strings: Pass more `string_view`s around, changed `CILess` to support them, changed `addNode()` to avoid creating shared strings if they're not needed. `CILess` now uses `_strnicmp()` because `string_view`s might not be null terminated.
- I changed `addFile()` and `addDirectory()` in `TreeContainer` to stop using recursion when reassigning the blocks and to retry outside of the catch. It was confusing the profiler, all the stuff that happened inside the root `catch` was merged into a `RcConsolidateFrames()` function.
- In `addNode()`, I removed some code in the `else`, the `insert()` call was useless:
   - At that point, `node()` returned something, so `m_Nodes` already contains the key
   - `insert()` doesn't do anything if the key already exists, so `newNode` is not copied over, and even if it did, it's the same object that's already in the map
   - `res.second` is therefore always `false` because the key already exists
