### PR TITLE
Switch is_directory to exists in assertPathExists

### DIFF
--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -649,7 +649,11 @@ bool assertPathExists(usvfs::RedirectionTreeContainer &table, LPCWSTR path)
           = current->data().linkTarget.size() > 0
                 ? bfs::path(current->data().linkTarget.c_str()) / *iter
                 : *iter / "\\";
-      if (exists(targetPath)) {
+      // ensure the path is either a directory, a symlink or a reparse point
+      // fixes wine compatibility as well as exotic windows setups.
+      // see pull request #47
+      if (is_directory(targetPath) || is_symlink(targetPath) ||
+	  status(targetPath).type() == bfs::file_type::reparse_file) {
         usvfs::RedirectionTree::NodePtrT newNode = table.addDirectory(
             current->path() / *iter, targetPath.string().c_str(),
             ush::FLAG_DUMMY, false);

--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -649,7 +649,7 @@ bool assertPathExists(usvfs::RedirectionTreeContainer &table, LPCWSTR path)
           = current->data().linkTarget.size() > 0
                 ? bfs::path(current->data().linkTarget.c_str()) / *iter
                 : *iter / "\\";
-      if (is_directory(targetPath)) {
+      if (exists(targetPath)) {
         usvfs::RedirectionTree::NodePtrT newNode = table.addDirectory(
             current->path() / *iter, targetPath.string().c_str(),
             ush::FLAG_DUMMY, false);


### PR DESCRIPTION
`is_directory` returns false for symbolic links and reparse points. This, combined with the fact that USVFS walks up the directory chain when adding an entry to the redirection tree, causes overlays to fail for directories where the path contains a symbolic link or a reparse point.

While that's fine for most users, people who use symbolic links to manage their game collection, or people who mount another disk in a NTFS directory, would be unable to overlay anything inside this game directory. It turns out that with the way Wine works internally, most Linux users actually have such a setup by default, and as of wine commit wine-mirror/wine@6b498d98a86b5179a025afbaaeaa3d60a8bd74ec, which exposes this internal detail to Win32 software, USVFS no longer works.

Changing the function from `is_directory` to `exists` seems to have fixed this issue with no adverse side-effects.