### PR TITLE
Trigger CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ platform:
 - x86
 environment:
   GTEST_PATH: C:\Libraries\googletest
-  BOOST_PATH: C:\Libraries\boost_1_75_0
+  BOOST_PATH: C:\Libraries\boost_1_77_0
   WEBHOOK_URL:
     secure: gOKbXaZM9ImtMD5XrYITvdyZUW/az082G9OIN1EC1VZ2CuYaUUM6WY2eiNxaFeOL7/9Jyu/m+Vm1fH54CEyigcUUaxA7d8F5IMWlOgE/7YYdaAFSMUTFD7EK+++3FBYfmU1F/nZ61wsiWE6hB9Au5FpGBSCeQ0Tf8U8m0ybPmD0=
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ platform:
 - x86
 environment:
   GTEST_PATH: C:\Libraries\googletest
-  BOOST_PATH: C:\Libraries\boost_1_71_0
+  BOOST_PATH: C:\Libraries\boost_1_75_0
   WEBHOOK_URL:
     secure: gOKbXaZM9ImtMD5XrYITvdyZUW/az082G9OIN1EC1VZ2CuYaUUM6WY2eiNxaFeOL7/9Jyu/m+Vm1fH54CEyigcUUaxA7d8F5IMWlOgE/7YYdaAFSMUTFD7EK+++3FBYfmU1F/nZ61wsiWE6hB9Au5FpGBSCeQ0Tf8U8m0ybPmD0=
 before_build:

--- a/include/usvfsparameters.h
+++ b/include/usvfsparameters.h
@@ -46,7 +46,6 @@ struct USVFSParameters {
   char crashDumpsPath[260];
 };
 
-
 struct usvfsParameters;
 
 DLLEXPORT usvfsParameters* usvfsCreateParameters();


### PR DESCRIPTION
As there hasn't been any new commits in months, the artifacts on appveyor have expired, which means the build system can't obtain them and fails. This is a dummy commit to trigger the CI to build new ones.