### PR TITLE
Readd some A hooks due to W11 changes

### DIFF
--- a/src/usvfs_dll/hookmanager.cpp
+++ b/src/usvfs_dll/hookmanager.cpp
@@ -222,6 +222,8 @@ void HookManager::initHooks()
   HMODULE kbaseMod = GetModuleHandleA("kernelbase.dll");
   spdlog::get("usvfs")->debug("kernelbase.dll at {0:x}", reinterpret_cast<uintptr_t>(kbaseMod));
 
+  installHook(kbaseMod, k32Mod, "GetFileAttributesExA", hook_GetFileAttributesExA);
+  installHook(kbaseMod, k32Mod, "GetFileAttributesA", hook_GetFileAttributesA);
   installHook(kbaseMod, k32Mod, "GetFileAttributesExW", hook_GetFileAttributesExW);
   installHook(kbaseMod, k32Mod, "GetFileAttributesW", hook_GetFileAttributesW);
   installHook(kbaseMod, k32Mod, "SetFileAttributesW", hook_SetFileAttributesW);
@@ -272,9 +274,11 @@ void HookManager::initHooks()
   installHook(ntdllMod, nullptr, "NtClose", hook_NtClose);
   installHook(ntdllMod, nullptr, "NtTerminateProcess", hook_NtTerminateProcess);
 
+  installHook(kbaseMod, k32Mod, "LoadLibraryExA", hook_LoadLibraryExA);
   installHook(kbaseMod, k32Mod, "LoadLibraryExW", hook_LoadLibraryExW);
 
   // install this hook late as usvfs is calling it itself for debugging purposes
+  installHook(kbaseMod, k32Mod, "GetModuleFileNameA", hook_GetModuleFileNameA);
   installHook(kbaseMod, k32Mod, "GetModuleFileNameW", hook_GetModuleFileNameW);
 
   spdlog::get("usvfs")->debug("hooks installed");

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -120,8 +120,17 @@ static inline bool pathsOnDifferentDrives(LPCWSTR path1, LPCWSTR path2)
 HMODULE WINAPI usvfs::hook_LoadLibraryExA(LPCSTR lpFileName, HANDLE hFile,
     DWORD dwFlags)
 {
-    return hook_LoadLibraryExW(
-        ush::string_cast<std::wstring>(lpFileName).c_str(), hFile, dwFlags);
+    HMODULE res = nullptr;
+
+    HOOK_START_GROUP(MutExHookGroup::LOAD_LIBRARY)
+    const std::wstring fileName = ush::string_cast<std::wstring>(lpFileName);
+
+    PRE_REALCALL
+    res = LoadLibraryExW(fileName.c_str(), hFile, dwFlags);
+    POST_REALCALL
+
+    HOOK_END
+    return res;
 }
 
 HMODULE WINAPI usvfs::hook_LoadLibraryExW(LPCWSTR lpFileName, HANDLE hFile,

--- a/src/usvfs_dll/hooks/kernel32.cpp
+++ b/src/usvfs_dll/hooks/kernel32.cpp
@@ -117,7 +117,12 @@ static inline bool pathsOnDifferentDrives(LPCWSTR path1, LPCWSTR path2)
   return drive1 && drive2 && towupper(drive1) != towupper(drive2);
 }
 
-
+HMODULE WINAPI usvfs::hook_LoadLibraryExA(LPCSTR lpFileName, HANDLE hFile,
+    DWORD dwFlags)
+{
+    return hook_LoadLibraryExW(
+        ush::string_cast<std::wstring>(lpFileName).c_str(), hFile, dwFlags);
+}
 
 HMODULE WINAPI usvfs::hook_LoadLibraryExW(LPCWSTR lpFileName, HANDLE hFile,
                                             DWORD dwFlags)
@@ -336,6 +341,31 @@ BOOL WINAPI usvfs::hook_CreateProcessInternalW(
   return res;
 }
 
+BOOL WINAPI usvfs::hook_GetFileAttributesExA(
+    LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId,
+    LPVOID lpFileInformation)
+{
+    BOOL res = FALSE;
+
+    HOOK_START_GROUP(MutExHookGroup::FILE_ATTRIBUTES)
+    if (!callContext.active() || !RerouteW::interestingPath(lpFileName)) {
+        res = GetFileAttributesExA(lpFileName, fInfoLevelId, lpFileInformation);
+        callContext.updateLastError();
+        return res;
+    }
+    HOOK_END
+
+    HOOK_START
+    const std::wstring fileName = ush::string_cast<std::wstring>(lpFileName);
+
+    PRE_REALCALL
+    res = GetFileAttributesExW(fileName.c_str(), fInfoLevelId, lpFileInformation);
+    POST_REALCALL
+
+    HOOK_END
+    return res;
+}
+
 BOOL WINAPI usvfs::hook_GetFileAttributesExW(
     LPCWSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId,
     LPVOID lpFileInformation)
@@ -405,6 +435,29 @@ BOOL WINAPI usvfs::hook_GetFileAttributesExW(
   HOOK_END
 
   return res;
+}
+
+DWORD WINAPI usvfs::hook_GetFileAttributesA(LPCSTR lpFileName)
+{
+    BOOL res = FALSE;
+
+    HOOK_START_GROUP(MutExHookGroup::FILE_ATTRIBUTES)
+    if (!callContext.active() || !RerouteW::interestingPath(lpFileName)) {
+        res = GetFileAttributesA(lpFileName);
+        callContext.updateLastError();
+        return res;
+    }
+    HOOK_END
+
+    HOOK_START
+    const std::wstring fileName = ush::string_cast<std::wstring>(lpFileName);
+
+    PRE_REALCALL
+    res = GetFileAttributesW(fileName.c_str());
+    POST_REALCALL
+
+    HOOK_END
+    return res;
 }
 
 DWORD WINAPI usvfs::hook_GetFileAttributesW(LPCWSTR lpFileName)
@@ -1219,6 +1272,32 @@ DWORD WINAPI usvfs::hook_GetFullPathNameW(LPCWSTR lpFileName,
   return res;
 }
 
+DWORD WINAPI usvfs::hook_GetModuleFileNameA(HMODULE hModule,
+    LPSTR lpFilename, DWORD nSize)
+{
+    DWORD res = 0;
+
+    HOOK_START
+
+    std::wstring buffer;
+    buffer.resize(nSize);
+
+    PRE_REALCALL
+    res = GetModuleFileNameW(hModule, &buffer[0], nSize);
+    POST_REALCALL
+
+    if (res > 0) {
+        res = WideCharToMultiByte(CP_ACP, 0, buffer.c_str(), res + 1,
+            lpFilename, nSize, nullptr, nullptr);
+        if (res > nSize) {
+            lpFilename[nSize - 1] = '\0';
+        }
+    }
+
+    HOOK_END
+
+    return res;
+}
 
 DWORD WINAPI usvfs::hook_GetModuleFileNameW(HMODULE hModule,
                                               LPWSTR lpFilename, DWORD nSize)

--- a/src/usvfs_dll/hooks/kernel32.h
+++ b/src/usvfs_dll/hooks/kernel32.h
@@ -5,7 +5,9 @@
 
 namespace usvfs {
 
+DLLEXPORT BOOL WINAPI hook_GetFileAttributesExA(LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, LPVOID lpFileInformation);
 DLLEXPORT BOOL WINAPI hook_GetFileAttributesExW(LPCWSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, LPVOID lpFileInformation);
+DLLEXPORT DWORD WINAPI hook_GetFileAttributesA(LPCSTR lpFileName);
 DLLEXPORT DWORD WINAPI hook_GetFileAttributesW(LPCWSTR lpFileName);
 DLLEXPORT DWORD WINAPI hook_SetFileAttributesW(LPCWSTR lpFileName, DWORD dwFileAttributes);
 
@@ -34,11 +36,13 @@ DLLEXPORT BOOL WINAPI hook_CopyFileExW(LPCWSTR lpExistingFileName, LPCWSTR lpNew
 extern HRESULT (WINAPI *CopyFile2)(PCWSTR pwszExistingFileName, PCWSTR pwszNewFileName, COPYFILE2_EXTENDED_PARAMETERS *pExtendedParameters);
 DLLEXPORT HRESULT WINAPI hook_CopyFile2(PCWSTR pwszExistingFileName, PCWSTR pwszNewFileName, COPYFILE2_EXTENDED_PARAMETERS *pExtendedParameters);
 
+DLLEXPORT HMODULE WINAPI hook_LoadLibraryExA(LPCSTR lpFileName, HANDLE hFile, DWORD dwFlags);
 DLLEXPORT HMODULE WINAPI hook_LoadLibraryExW(LPCWSTR lpFileName, HANDLE hFile, DWORD dwFlags);
 
 extern BOOL (WINAPI *CreateProcessInternalW)(LPVOID token, LPCWSTR lpApplicationName, LPWSTR lpCommandLine, LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo, LPPROCESS_INFORMATION lpProcessInformation, LPVOID newToken);
 DLLEXPORT BOOL WINAPI hook_CreateProcessInternalW(LPVOID token, LPCWSTR lpApplicationName, LPWSTR lpCommandLine, LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo, LPPROCESS_INFORMATION lpProcessInformation, LPVOID newToken);
 
+DLLEXPORT DWORD WINAPI hook_GetModuleFileNameA(HMODULE hModule, LPSTR lpFilename, DWORD nSize);
 DLLEXPORT DWORD WINAPI hook_GetModuleFileNameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize);
 
 DLLEXPORT HANDLE WINAPI hook_FindFirstFileExW(LPCWSTR lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, LPVOID lpFindFileData, FINDEX_SEARCH_OPS  fSearchOp, LPVOID lpSearchFilter, DWORD dwAdditionalFlags);


### PR DESCRIPTION
- GetFileAttributes(Ex)A
- LoadLibraryExA
- GetModuleFileNameA

Admittedly only GetModuleFileNameA is a known issue

I believe this supersedes #72