### PR TITLE
Better debugging mode.

### DIFF
--- a/src/usvfs_dll/hookcontext.cpp
+++ b/src/usvfs_dll/hookcontext.cpp
@@ -65,7 +65,7 @@ HookContext::HookContext(const usvfsParameters& params, HMODULE module)
           m_Parameters->currentInverseSHMName(),
           128 * 1024)  // 128 KiB should cover reverse tree for even larger setups
       ,
-      m_DebugMode(params.debugMode), m_DLLModule(module)
+      m_DLLModule(module)
 {
   if (s_Instance != nullptr) {
     throw std::runtime_error("singleton duplicate instantiation (HookContext)");

--- a/src/usvfs_dll/hookcontext.h
+++ b/src/usvfs_dll/hookcontext.h
@@ -92,11 +92,6 @@ public:
   usvfsParameters callParameters() const;
 
   /**
-   * @return true if usvfs is running in debug mode
-   */
-  bool debugMode() const { return m_DebugMode; }
-
-  /**
    * @return path to the calling library itself
    */
   std::wstring dllPath() const;
@@ -169,8 +164,6 @@ private:
   std::vector<std::future<int>> m_Futures;
 
   mutable std::map<DataIDT, boost::any> m_CustomData;
-
-  bool m_DebugMode{false};
 
   HMODULE m_DLLModule;
 

--- a/src/usvfs_dll/hookmanager.cpp
+++ b/src/usvfs_dll/hookmanager.cpp
@@ -63,7 +63,10 @@ HookManager::HookManager(const usvfsParameters& params, HMODULE module)
   initHooks();
 
   if (params.debugMode) {
-    MessageBoxA(nullptr, "Hooks initialized", "Pause", MB_OK);
+    while (!::IsDebuggerPresent()) {
+      // wait for debugger to attach
+      ::Sleep(100);
+    }
   }
 }
 

--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -376,7 +376,18 @@ void __cdecl InitHooks(LPVOID parameters, size_t)
   InitLoggingInternal(false, true);
 
   const usvfsParameters* params = reinterpret_cast<usvfsParameters*>(parameters);
-  usvfs_dump_type               = params->crashDumpsType;
+
+  // there is already a wait in the constructor of HookManager, but this one is useful
+  // to debug code here (from experience... ), should not wait twice since the second
+  // will return true immediately
+  if (params->debugMode) {
+    while (!::IsDebuggerPresent()) {
+      // wait for debugger to attach
+      ::Sleep(100);
+    }
+  }
+
+  usvfs_dump_type = params->crashDumpsType;
   usvfs_dump_path =
       ush::string_cast<std::wstring>(params->crashDumpsPath, ush::CodePage::UTF8);
 


### PR DESCRIPTION
Small changes that uses [IsDebuggerPresent](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-isdebuggerpresent) instead of a popup to wait for debugger.

Since this is non-blocking (compared to the previous popup), I also added a wait loop at the beginning of the injection process (very useful).

I also removed the debug attribute of `HookContext` since it was used nowhere.