### PR TITLE
implement minor improvements in existing code

### DIFF
--- a/src/shared/tree_container.h
+++ b/src/shared/tree_container.h
@@ -442,7 +442,7 @@ private:
     }
 
     const int count = boost::lexical_cast<int>(match[2]);
-    return match[1].str() + std::to_string(count + 1);
+    return std::format("{}{}", match[1].str(), count + 1);
   }
 
   bool unassign(const std::shared_ptr<SharedMemoryT>& shm, TreeMeta* tree)

--- a/src/shared/winapi.cpp
+++ b/src/shared/winapi.cpp
@@ -432,7 +432,8 @@ std::vector<FileResult> quickFindFiles(LPCWSTR directoryName, LPCWSTR pattern)
   return result;
 }
 
-bool createPath(const boost::filesystem::path& path, LPSECURITY_ATTRIBUTES securityAttributes)
+bool createPath(const boost::filesystem::path& path,
+                LPSECURITY_ATTRIBUTES securityAttributes)
 {
   // sanity and guaranteed recursion end:
   if (!path.has_relative_path())

--- a/src/shared/winapi.cpp
+++ b/src/shared/winapi.cpp
@@ -432,7 +432,7 @@ std::vector<FileResult> quickFindFiles(LPCWSTR directoryName, LPCWSTR pattern)
   return result;
 }
 
-bool createPath(boost::filesystem::path path, LPSECURITY_ATTRIBUTES securityAttributes)
+bool createPath(const boost::filesystem::path& path, LPSECURITY_ATTRIBUTES securityAttributes)
 {
   // sanity and guaranteed recursion end:
   if (!path.has_relative_path())

--- a/src/shared/winapi.h
+++ b/src/shared/winapi.h
@@ -542,7 +542,7 @@ std::vector<FileResult> quickFindFiles(LPCWSTR directoryName, LPCWSTR pattern);
  * @return true if the directory (and possibly parent directories) were actually created
  *        and false if the directory already existed. Throws exceptions on failure.
  */
-bool createPath(boost::filesystem::path path,
+bool createPath(const boost::filesystem::path& path,
                 LPSECURITY_ATTRIBUTES securityAttributes = nullptr);
 inline bool createPath(LPCWSTR path, LPSECURITY_ATTRIBUTES securityAttributes = nullptr)
 {

--- a/src/thooklib/ttrampolinepool.cpp
+++ b/src/thooklib/ttrampolinepool.cpp
@@ -474,7 +474,9 @@ LPVOID TrampolinePool::currentBufferAddress(LPVOID addressNear)
   auto lookupAddress = m_Buffers.find(rounded);
 
   if (lookupAddress == m_Buffers.end()) {
-    lookupAddress = m_Buffers.try_emplace(rounded /* automatically emplaces default BufferList() */).first;
+    lookupAddress =
+        m_Buffers.try_emplace(rounded /* automatically emplaces default BufferList() */)
+            .first;
   }
   if (lookupAddress->second.buffers.empty()) {
     allocateBuffer(addressNear);

--- a/src/thooklib/ttrampolinepool.cpp
+++ b/src/thooklib/ttrampolinepool.cpp
@@ -474,9 +474,9 @@ LPVOID TrampolinePool::currentBufferAddress(LPVOID addressNear)
   auto lookupAddress = m_Buffers.find(rounded);
 
   if (lookupAddress == m_Buffers.end()) {
-    lookupAddress = m_Buffers.insert(std::make_pair(rounded, BufferList())).first;
+    lookupAddress = m_Buffers.try_emplace(rounded /* automatically emplaces default BufferList() */).first;
   }
-  if (lookupAddress->second.buffers.size() == 0) {
+  if (lookupAddress->second.buffers.empty()) {
     allocateBuffer(addressNear);
   }
 
@@ -503,7 +503,7 @@ TrampolinePool::BufferMap::iterator TrampolinePool::allocateBuffer(LPVOID addres
   LPVOID rounded     = roundAddress(addressNear);
   auto iter          = m_Buffers.find(rounded);
   uintptr_t lowerEnd = reinterpret_cast<uintptr_t>(rounded);
-  if (iter->second.buffers.size() > 0) {
+  if (!iter->second.buffers.empty()) {
     // start searching were we last found a buffer
     lowerEnd = reinterpret_cast<uintptr_t>(*iter->second.buffers.rbegin()) +
                sysInfo.dwPageSize;
@@ -584,8 +584,7 @@ LPVOID TrampolinePool::releaseInt(LPVOID func)
     m_ThreadGuards.reset(new TThreadMap());
   }
 
-  auto iter = m_ThreadGuards->find(func);
-  if (iter == m_ThreadGuards->end()) {
+  if (!m_ThreadGuards->contains(func)) {
     spdlog::get("hooks")->error("failed to release barrier for func {}", func);
     ::SetLastError(lastError);
     return nullptr;

--- a/src/usvfs_dll/hookmanager.cpp
+++ b/src/usvfs_dll/hookmanager.cpp
@@ -167,8 +167,8 @@ void HookManager::installHook(HMODULE module1, HMODULE module2,
     spdlog::get("usvfs")->error("failed to hook {0}: {1}", functionName,
                                 GetErrorString(err));
   } else {
-    m_Stubs.insert(make_pair(funcAddr, functionName));
-    m_Hooks.insert(make_pair(std::string(functionName), handle));
+    m_Stubs.try_emplace(funcAddr, functionName);
+    m_Hooks.try_emplace(std::string(functionName), handle);
     spdlog::get("usvfs")->info("hooked {0} ({1}) in {2} type {3}", functionName,
                                funcAddr, winapi::ansi::getModuleFileName(usedModule),
                                GetHookType(handle));
@@ -213,8 +213,8 @@ void HookManager::installStub(HMODULE module1, HMODULE module2,
     spdlog::get("usvfs")->error("failed to stub {0}: {1}", functionName,
                                 GetErrorString(err));
   } else {
-    m_Stubs.insert(make_pair(funcAddr, functionName));
-    m_Hooks.insert(make_pair(std::string(functionName), handle));
+    m_Stubs.try_emplace(funcAddr, functionName);
+    m_Hooks.try_emplace(std::string(functionName), handle);
     spdlog::get("usvfs")->info("stubbed {0} ({1}) in {2} type {3}", functionName,
                                funcAddr, winapi::ansi::getModuleFileName(usedModule),
                                GetHookType(handle));

--- a/src/usvfs_dll/maptracker.h
+++ b/src/usvfs_dll/maptracker.h
@@ -221,7 +221,7 @@ public:
     }
   }
 
-  static bool createFakePath(fs::path path, LPSECURITY_ATTRIBUTES securityAttributes)
+  static bool createFakePath(const fs::path& path, LPSECURITY_ATTRIBUTES securityAttributes)
   {
     // sanity and guaranteed recursion end:
     if (!path.has_relative_path())
@@ -516,7 +516,7 @@ public:
       auto res = create(context, callContext, inPath);
       if (res.wasRerouted() || !interestingPath(inPath) || !callContext.active() ||
           pathExists(inPath))
-        return std::move(res);
+        return res;
     }
     return createNew(context, callContext, inPath, createPath, securityAttributes);
   }

--- a/src/usvfs_dll/maptracker.h
+++ b/src/usvfs_dll/maptracker.h
@@ -221,7 +221,8 @@ public:
     }
   }
 
-  static bool createFakePath(const fs::path& path, LPSECURITY_ATTRIBUTES securityAttributes)
+  static bool createFakePath(const fs::path& path,
+                             LPSECURITY_ATTRIBUTES securityAttributes)
   {
     // sanity and guaranteed recursion end:
     if (!path.has_relative_path())

--- a/src/usvfs_dll/usvfs.cpp
+++ b/src/usvfs_dll/usvfs.cpp
@@ -418,7 +418,7 @@ void __cdecl InitHooks(LPVOID parameters, size_t)
     auto context   = manager->context();
     auto exePath   = boost::dll::program_location();
     auto libraries = context->librariesToForceLoad(exePath.filename().c_str());
-    for (auto library : libraries) {
+    for (const auto& library : libraries) {
       if (std::filesystem::exists(library)) {
         const auto ret = LoadLibraryExW(library.c_str(), NULL, 0);
         if (ret) {
@@ -588,9 +588,9 @@ bool assertPathExists(usvfs::RedirectionTreeContainer& table, LPCWSTR path)
   usvfs::RedirectionTree::NodeT* current = table.get();
 
   for (auto iter = p.begin(); iter != p.end(); iter = ush::nextIter(iter, p.end())) {
-    if (current->exists(iter->string().c_str())) {
+    if (current->exists(iter->string())) {
       // subdirectory exists virtually, all good
-      usvfs::RedirectionTree::NodePtrT found = current->node(iter->string().c_str());
+      usvfs::RedirectionTree::NodePtrT found = current->node(iter->string());
       current                                = found.get().get();
     } else {
       // targetPath is relative to the last rerouted "real" path. This means


### PR DESCRIPTION
Going through the code, I encountered a few instances where minor improvements can be made.

### tree_container.h
- `std::format` avoids creating temporary strings that then get concatenated, allowing the compiler to do in-place string construction.
### winapi
- we can pass the path object as a const reference to avoid copying it for the (recursive) function call `createPath`.
### ttrampolinepool.cpp
- using try_emplace instead of insert allows creating the pair in-place without instantiating a local object first. It will also instantiate a default BufferList() as before, but I added a comment to make it clear
- using `buffers.empty()` can be more efficient than comparing to `buffers.size()` depending on the implementation of size() and makes the code easier to understand
- using `!m_ThreadGuards->contains(func)` makes the code easier to understand
### hookmanager.cpp
- try_emplace allows in-place construction
### maptracker.h
- see winapi, same code for `createFakePath` as `createPath`
- the explicit call to `std::move` when returning a local variable prevents the compiler from doing copy elision optimizations here. Without it, the compiler can potentially further optimize the function.
### usvfs.cpp
- using constant references to the library strings prevents temporary copies of those strings
- as `RedirectionTree::exists` accepts a string_view there is no need to transform the iterator string to a c_str.

## Tests
All tests still pass and I've had no issues using MO2, starting programs or games through MO2 and playing heavily-modded skyrirm for example.